### PR TITLE
bumped version to 1.1.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.monta.slack.notifier"
-version = "1.1.0"
+version = "1.1.1"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
In an attempt to see if the previous build broke because of problems with tagging twice