### PR TITLE
fix: reduce github context read from env to mitigate "argument list too long" bug

### DIFF
--- a/src/commonMain/kotlin/com/monta/slack/notifier/service/PublishSlackService.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/service/PublishSlackService.kt
@@ -4,7 +4,6 @@ import com.monta.slack.notifier.SlackClient
 import com.monta.slack.notifier.model.GithubPushContext
 import com.monta.slack.notifier.model.JobStatus
 import com.monta.slack.notifier.model.JobType
-import com.monta.slack.notifier.util.JsonUtil
 import com.monta.slack.notifier.util.writeToOutput
 
 class PublishSlackService(
@@ -22,13 +21,11 @@ class PublishSlackService(
     )
 
     suspend fun publish(
-        githubContext: String,
+        githubPushContext: GithubPushContext,
         jobType: JobType,
         jobStatus: JobStatus,
         slackMessageId: String?
     ): String {
-        val githubPushContext = JsonUtil.instance.decodeFromString<GithubPushContext>(githubContext)
-
         val messageId = if (slackMessageId.isNullOrBlank()) {
             slackClient.create(
                 githubPushContext = githubPushContext,

--- a/src/commonMain/kotlin/com/monta/slack/notifier/util/FileUtils.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/util/FileUtils.kt
@@ -1,0 +1,29 @@
+package com.monta.slack.notifier.util
+
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import platform.posix.fclose
+import platform.posix.fgets
+import platform.posix.fopen
+
+fun readStringFromFile(filePath: String): String {
+    val returnBuffer = StringBuilder()
+    val file = fopen(filePath, "r")
+        ?: throw IllegalArgumentException("Cannot open file $filePath for reading")
+    try {
+        memScoped {
+            val readBufferLength = 64 * 1024
+            val buffer = allocArray<ByteVar>(readBufferLength)
+            var line = fgets(buffer, readBufferLength, file)?.toKString()
+            while (line != null) {
+                returnBuffer.append(line)
+                line = fgets(buffer, readBufferLength, file)?.toKString()
+            }
+        }
+    } finally {
+        fclose(file)
+    }
+    return returnBuffer.toString()
+}


### PR DESCRIPTION
This reduces the amount of data needed to be passed via environment variables or parameter arguments by relying on reading the necessary github context from a few specific environment variables as well as from a json file, all of which are readily and automatically available when using this in github actions. The names of the environment variables used in the options reflect this.

This change was trigged by a [grid deploy](https://github.com/monta-app/service-grid/actions/runs/5928170076/job/16073192609#step:2:1607) that failed with a shell error "Argument list too long". The shell's "argument list" size includes its environment, and in this case (due to some very long changelogs being included in a bunch of dependabot commits) the full github context passed in an env var was ~130kB.