### PR TITLE
feat(cli): Attempt at patching the existing event with a new file reader to support trunk based flows

### DIFF
--- a/src/commonMain/kotlin/com/monta/slack/notifier/command/PublishSlackCommand.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/command/PublishSlackCommand.kt
@@ -4,7 +4,6 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.monta.slack.notifier.model.GithubPushContext
-import com.monta.slack.notifier.model.GithubTrunkBasedPushContext
 import com.monta.slack.notifier.model.JobStatus
 import com.monta.slack.notifier.model.JobType
 import com.monta.slack.notifier.service.PublishSlackService

--- a/src/commonMain/kotlin/com/monta/slack/notifier/model/GithubPushContext.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/model/GithubPushContext.kt
@@ -33,7 +33,7 @@ data class GithubPushContext(
     @Serializable
     data class Event(
         @SerialName("head_commit")
-        val headCommit: Commit? = null,
+        var headCommit: Commit? = null,
         @SerialName("pusher")
         val pusher: Committer? = null,
         @SerialName("ref")

--- a/src/commonMain/kotlin/com/monta/slack/notifier/model/GithubTrunkBasedPushContext.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/model/GithubTrunkBasedPushContext.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 data class GithubTrunkBasedPushContext(
     @SerialName("run_id")
     val runId: String? = null, // 4. Fourth var, Name of run (should be )
-){
+) {
     // In this class we grab variables from a trunk based event flow
     // Where each thing we need to populate the slack message are listed
     @Serializable
@@ -19,17 +19,17 @@ data class GithubTrunkBasedPushContext(
     data class PullRequest(
         @SerialName("head") val head: PullRequestHead,
         @SerialName("title") val title: String,
-        @SerialName("user") val user: PullRequestUser
+        @SerialName("user") val user: PullRequestUser,
     )
 
     @Serializable
     data class PullRequestUser(
-        @SerialName("login") val login: String
+        @SerialName("login") val login: String,
     )
 
     @Serializable
     data class Repository(
-        @SerialName("full_name") val fullName: String
+        @SerialName("full_name") val fullName: String,
     )
 
     @Serializable

--- a/src/commonMain/kotlin/com/monta/slack/notifier/model/GithubTrunkBasedPushContext.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/model/GithubTrunkBasedPushContext.kt
@@ -1,0 +1,41 @@
+package com.monta.slack.notifier.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GithubTrunkBasedPushContext(
+    @SerialName("run_id")
+    val runId: String? = null, // 4. Fourth var, Name of run (should be )
+){
+    // In this class we grab variables from a trunk based event flow
+    // Where each thing we need to populate the slack message are listed
+    @Serializable
+    data class PullRequestHead(
+        @SerialName("ref") val ref: String, //  1. First var, Name of branch
+    )
+
+    @Serializable
+    data class PullRequest(
+        @SerialName("head") val head: PullRequestHead,
+        @SerialName("title") val title: String, //  5. Fifth var, Name of message
+        @SerialName("user") val user: PullRequestUser
+    )
+
+    @Serializable
+    data class PullRequestUser(
+        @SerialName("login") val login: String //  2. second var, Name of comitter
+    )
+
+    @Serializable
+    data class Repository(
+        @SerialName("full_name") val fullName: String
+    )
+
+    @Serializable
+    data class Event(
+        @SerialName("after") val sha: String, // 3. Third var, SHA
+        @SerialName("pull_request") val pullRequest: PullRequest,
+        @SerialName("repository") val repository: Repository,
+    )
+}

--- a/src/commonMain/kotlin/com/monta/slack/notifier/model/GithubTrunkBasedPushContext.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/model/GithubTrunkBasedPushContext.kt
@@ -12,19 +12,19 @@ data class GithubTrunkBasedPushContext(
     // Where each thing we need to populate the slack message are listed
     @Serializable
     data class PullRequestHead(
-        @SerialName("ref") val ref: String, //  1. First var, Name of branch
+        @SerialName("ref") val ref: String,
     )
 
     @Serializable
     data class PullRequest(
         @SerialName("head") val head: PullRequestHead,
-        @SerialName("title") val title: String, //  5. Fifth var, Name of message
+        @SerialName("title") val title: String,
         @SerialName("user") val user: PullRequestUser
     )
 
     @Serializable
     data class PullRequestUser(
-        @SerialName("login") val login: String //  2. second var, Name of comitter
+        @SerialName("login") val login: String
     )
 
     @Serializable
@@ -34,7 +34,7 @@ data class GithubTrunkBasedPushContext(
 
     @Serializable
     data class Event(
-        @SerialName("after") val sha: String, // 3. Third var, SHA
+        @SerialName("after") val sha: String,
         @SerialName("pull_request") val pullRequest: PullRequest,
         @SerialName("repository") val repository: Repository,
     )

--- a/src/commonMain/kotlin/com/monta/slack/notifier/util/TrunkUtils.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/util/TrunkUtils.kt
@@ -8,7 +8,7 @@ import com.monta.slack.notifier.model.GithubTrunkBasedPushContext
  * an entire Slack notification. This is super hacky but an easy solution
  * without deintegrating GithubPushContext from the rest of the code.
  */
-fun populateEventFromTrunkBasedEvent(eventJson: String, event :GithubPushContext.Event) : GithubPushContext.Event {
+fun populateEventFromTrunkBasedEvent(eventJson: String, event: GithubPushContext.Event): GithubPushContext.Event {
     val trunkBasedEvent = JsonUtil.instance.decodeFromString<GithubTrunkBasedPushContext.Event>(eventJson)
     event.headCommit = GithubPushContext.Commit(
         committer = GithubPushContext.Committer(name = trunkBasedEvent.pullRequest.user.login),

--- a/src/commonMain/kotlin/com/monta/slack/notifier/util/TrunkUtils.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/util/TrunkUtils.kt
@@ -1,0 +1,20 @@
+package com.monta.slack.notifier.util
+
+import com.monta.slack.notifier.model.GithubPushContext
+import com.monta.slack.notifier.model.GithubTrunkBasedPushContext
+
+/**
+ * Populates the existing event type with information needed to generate
+ * an entire Slack notification. This is super hacky but an easy solution
+ * without deintegrating GithubPushContext from the rest of the code.
+ */
+fun populateEventFromTrunkBasedEvent(eventJson: String, event :GithubPushContext.Event) : GithubPushContext.Event {
+    val trunkBasedEvent = JsonUtil.instance.decodeFromString<GithubTrunkBasedPushContext.Event>(eventJson)
+    event.headCommit = GithubPushContext.Commit(
+        committer = GithubPushContext.Committer(name = trunkBasedEvent.pullRequest.user.login),
+        id = trunkBasedEvent.sha,
+        url = "https://github.com/${trunkBasedEvent.repository.fullName}/compare/${trunkBasedEvent.pullRequest.head.ref}",
+        message = trunkBasedEvent.pullRequest.title
+    )
+    return event
+}


### PR DESCRIPTION
For trunk based builds, the Slack notifications are broken like this example: 
https://monta-app01.slack.com/archives/C01KL9FUPNK/p1713440134273099

Trunk based flows use another pattern for their github json events. The original class GithubPushContext, is coupled with the `PublishSlackService` and `PublishSlackCommand`, so to avoid re-writing these i created a quick util method which populates the original context with the new info. 

Theres prob also a way of doing this in a OOP style which would be cleaner and better but for now i think this is alright. 