### PR TITLE
feat: Support appending to message attachments instead of replacing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ kotlin {
                 implementation(kotlin("test-annotations-common"))
                 implementation("io.kotest:kotest-framework-engine:$kotestVersion")
                 implementation("io.kotest:kotest-assertions-core:$kotestVersion")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
             }
         }
     }

--- a/src/commonMain/kotlin/com/monta/slack/notifier/SlackClient.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/SlackClient.kt
@@ -5,14 +5,16 @@ import com.monta.slack.notifier.model.JobStatus
 import com.monta.slack.notifier.model.JobType
 import com.monta.slack.notifier.model.SlackBlock
 import com.monta.slack.notifier.model.SlackMessage
-import com.monta.slack.notifier.service.Input
 import com.monta.slack.notifier.util.buildTitle
 import kotlinx.datetime.LocalDateTime
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class SlackClient(
-    private val input: Input,
+    private val serviceName: String?,
+    private val serviceEmoji: String?,
+    private val slackChannelId: String,
+    private val appendAttachments: Boolean,
     private val slackHttpClient: SlackHttpClient,
 ) {
     suspend fun create(
@@ -119,7 +121,7 @@ class SlackClient(
         messageId: String? = null,
         previousAttachments: List<SlackMessage.Attachment>? = null,
     ): SlackMessage {
-        val attachments = if (input.appendAttachments) {
+        val attachments = if (appendAttachments) {
             previousAttachments.orEmpty() + SlackMessage.Attachment(
                 color = jobStatus.color,
                 fields = listOf(
@@ -156,9 +158,9 @@ class SlackClient(
 
         return generateSlackMessageFromEvent(
             githubEvent = githubEvent,
-            serviceName = input.serviceName,
-            serviceEmoji = input.serviceEmoji,
-            slackChannelId = input.slackChannelId,
+            serviceName = serviceName,
+            serviceEmoji = serviceEmoji,
+            slackChannelId = slackChannelId,
             messageId = messageId,
             attachments = attachments
         )

--- a/src/commonMain/kotlin/com/monta/slack/notifier/SlackClient.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/SlackClient.kt
@@ -166,7 +166,6 @@ class SlackClient(
         )
     }
 
-
     @Serializable
     data class Response(
         @SerialName("ok")

--- a/src/commonMain/kotlin/com/monta/slack/notifier/SlackHttpClient.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/SlackHttpClient.kt
@@ -11,8 +11,10 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.request.url
 import io.ktor.client.statement.bodyAsText
-import io.ktor.http.*
-import io.ktor.utils.io.charsets.*
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.utils.io.charsets.Charsets
+import io.ktor.utils.io.charsets.name
 
 open class SlackHttpClient(
     private val slackToken: String,
@@ -23,7 +25,7 @@ open class SlackHttpClient(
         messageId: String,
     ): MessageResponse? {
         val response = client.get {
-            header("Authorization", "Bearer ${slackToken}")
+            header("Authorization", "Bearer $slackToken")
             url {
                 url("https://slack.com/api/conversations.history")
                 parameters.append("channel", slackChannelId)
@@ -46,7 +48,7 @@ open class SlackHttpClient(
 
     open suspend fun makeSlackRequest(url: String, message: SlackMessage): Response? {
         val response = client.post(url) {
-            header("Authorization", "Bearer ${slackToken}")
+            header("Authorization", "Bearer $slackToken")
             contentType(ContentType.Application.Json.withParameter("charset", Charsets.UTF_8.name))
             setBody(message)
         }
@@ -61,6 +63,4 @@ open class SlackHttpClient(
             null
         }
     }
-
-
 }

--- a/src/commonMain/kotlin/com/monta/slack/notifier/SlackHttpClient.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/SlackHttpClient.kt
@@ -3,10 +3,8 @@ package com.monta.slack.notifier
 import com.monta.slack.notifier.SlackClient.MessageResponse
 import com.monta.slack.notifier.SlackClient.Response
 import com.monta.slack.notifier.model.SlackMessage
-import com.monta.slack.notifier.service.Input
 import com.monta.slack.notifier.util.JsonUtil
 import com.monta.slack.notifier.util.client
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -17,17 +15,18 @@ import io.ktor.http.*
 import io.ktor.utils.io.charsets.*
 
 open class SlackHttpClient(
-    private val input: Input,
+    private val slackToken: String,
+    private val slackChannelId: String,
 ) {
 
     open suspend fun getSlackMessageById(
         messageId: String,
     ): MessageResponse? {
         val response = client.get {
-            header("Authorization", "Bearer ${input.slackToken}")
+            header("Authorization", "Bearer ${slackToken}")
             url {
                 url("https://slack.com/api/conversations.history")
-                parameters.append("channel", input.slackChannelId)
+                parameters.append("channel", slackChannelId)
                 parameters.append("oldest", messageId)
                 parameters.append("inclusive", "true")
                 parameters.append("limit", "1")
@@ -47,7 +46,7 @@ open class SlackHttpClient(
 
     open suspend fun makeSlackRequest(url: String, message: SlackMessage): Response? {
         val response = client.post(url) {
-            header("Authorization", "Bearer ${input.slackToken}")
+            header("Authorization", "Bearer ${slackToken}")
             contentType(ContentType.Application.Json.withParameter("charset", Charsets.UTF_8.name))
             setBody(message)
         }

--- a/src/commonMain/kotlin/com/monta/slack/notifier/SlackHttpClient.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/SlackHttpClient.kt
@@ -1,0 +1,67 @@
+package com.monta.slack.notifier
+
+import com.monta.slack.notifier.SlackClient.MessageResponse
+import com.monta.slack.notifier.SlackClient.Response
+import com.monta.slack.notifier.model.SlackMessage
+import com.monta.slack.notifier.service.Input
+import com.monta.slack.notifier.util.JsonUtil
+import com.monta.slack.notifier.util.client
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.request.url
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.*
+import io.ktor.utils.io.charsets.*
+
+open class SlackHttpClient(
+    private val input: Input,
+) {
+
+    open suspend fun getSlackMessageById(
+        messageId: String,
+    ): MessageResponse? {
+        val response = client.get {
+            header("Authorization", "Bearer ${input.slackToken}")
+            url {
+                url("https://slack.com/api/conversations.history")
+                parameters.append("channel", input.slackChannelId)
+                parameters.append("oldest", messageId)
+                parameters.append("inclusive", "true")
+                parameters.append("limit", "1")
+            }
+        }
+
+        val bodyString = response.bodyAsText()
+
+        return if (response.status.value in 200..299) {
+            println("successfully got message bodyString=$bodyString")
+            JsonUtil.instance.decodeFromString(bodyString)
+        } else {
+            println("failed to get message $bodyString")
+            null
+        }
+    }
+
+    open suspend fun makeSlackRequest(url: String, message: SlackMessage): Response? {
+        val response = client.post(url) {
+            header("Authorization", "Bearer ${input.slackToken}")
+            contentType(ContentType.Application.Json.withParameter("charset", Charsets.UTF_8.name))
+            setBody(message)
+        }
+
+        val bodyString = response.bodyAsText()
+
+        return if (response.status.value in 200..299) {
+            println("successfully posted message bodyString=$bodyString")
+            JsonUtil.instance.decodeFromString(bodyString)
+        } else {
+            println("failed to post message $bodyString")
+            null
+        }
+    }
+
+
+}

--- a/src/commonMain/kotlin/com/monta/slack/notifier/command/PublishSlackCommand.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/command/PublishSlackCommand.kt
@@ -8,9 +8,7 @@ import com.monta.slack.notifier.model.GithubEvent
 import com.monta.slack.notifier.model.JobStatus
 import com.monta.slack.notifier.model.JobType
 import com.monta.slack.notifier.model.serializers.BaseGithubContext
-import com.monta.slack.notifier.service.Input
 import com.monta.slack.notifier.service.PublishSlackService
-import com.monta.slack.notifier.util.client
 import com.monta.slack.notifier.util.populateEventFromJson
 import com.monta.slack.notifier.util.readStringFromFile
 import kotlinx.coroutines.runBlocking
@@ -84,16 +82,12 @@ class PublishSlackCommand : CliktCommand() {
     override fun run() {
         runBlocking {
             val githubEvent = getGithubEvent()
-            val input = Input(
+            PublishSlackService(
                 serviceName = serviceName.valueOrNull(),
                 serviceEmoji = serviceEmoji.valueOrNull(),
-                slackToken = slackToken,
                 slackChannelId = slackChannelId,
-                appendAttachments = appendStatusUpdates.toBoolean()
-            )
-            PublishSlackService(
-                input = input,
-                slackHttpClient = SlackHttpClient(input)
+                appendAttachments = appendStatusUpdates.toBoolean(),
+                slackHttpClient = SlackHttpClient(slackToken, slackChannelId)
             ).publish(
                 githubEvent = githubEvent,
                 jobType = JobType.fromString(jobType),

--- a/src/commonMain/kotlin/com/monta/slack/notifier/service/PublishSlackService.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/service/PublishSlackService.kt
@@ -7,20 +7,18 @@ import com.monta.slack.notifier.model.JobStatus
 import com.monta.slack.notifier.model.JobType
 import com.monta.slack.notifier.util.writeToOutput
 
-data class Input(
-    val serviceName: String?,
-    val serviceEmoji: String?,
-    val slackToken: String,
-    val slackChannelId: String,
-    val appendAttachments: Boolean = false,
-)
-
 class PublishSlackService(
-    input: Input,
-    slackHttpClient: SlackHttpClient,
+    private val serviceName: String?,
+    private val serviceEmoji: String?,
+    private val slackChannelId: String,
+    private val appendAttachments: Boolean = false,
+    private val slackHttpClient: SlackHttpClient,
 ) {
     private val slackClient = SlackClient(
-        input = input,
+        serviceName = serviceName,
+        serviceEmoji = serviceEmoji,
+        slackChannelId = slackChannelId,
+        appendAttachments = appendAttachments,
         slackHttpClient = slackHttpClient
     )
 

--- a/src/commonMain/kotlin/com/monta/slack/notifier/service/PublishSlackService.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/service/PublishSlackService.kt
@@ -1,23 +1,27 @@
 package com.monta.slack.notifier.service
 
 import com.monta.slack.notifier.SlackClient
+import com.monta.slack.notifier.SlackHttpClient
 import com.monta.slack.notifier.model.GithubEvent
 import com.monta.slack.notifier.model.JobStatus
 import com.monta.slack.notifier.model.JobType
 import com.monta.slack.notifier.util.writeToOutput
 
-class PublishSlackService(
-    serviceName: String?,
-    serviceEmoji: String?,
-    slackToken: String,
-    slackChannelId: String,
-) {
+data class Input(
+    val serviceName: String?,
+    val serviceEmoji: String?,
+    val slackToken: String,
+    val slackChannelId: String,
+    val appendAttachments: Boolean = false,
+)
 
+class PublishSlackService(
+    input: Input,
+    slackHttpClient: SlackHttpClient,
+) {
     private val slackClient = SlackClient(
-        serviceName = serviceName,
-        serviceEmoji = serviceEmoji,
-        slackToken = slackToken,
-        slackChannelId = slackChannelId
+        input = input,
+        slackHttpClient = slackHttpClient
     )
 
     suspend fun publish(
@@ -37,7 +41,7 @@ class PublishSlackService(
                 messageId = slackMessageId,
                 githubEvent = githubEvent,
                 jobType = jobType,
-                jobStatus = jobStatus
+                jobStatus = jobStatus,
             )
         }
 

--- a/src/commonTest/kotlin/com/monta/slack/notifier/service/PublishSlackServiceTest.kt
+++ b/src/commonTest/kotlin/com/monta/slack/notifier/service/PublishSlackServiceTest.kt
@@ -84,9 +84,7 @@ class PublishSlackServiceTest {
             val slackMessagesAfter = testSlackHttpClient.listMessages()
             slackMessagesAfter.size shouldBe 2
             slackMessagesAfter.last().attachments?.size shouldBe 1
-
         }
-
     }
 
     @Test

--- a/src/commonTest/kotlin/com/monta/slack/notifier/service/PublishSlackServiceTest.kt
+++ b/src/commonTest/kotlin/com/monta/slack/notifier/service/PublishSlackServiceTest.kt
@@ -1,0 +1,154 @@
+package com.monta.slack.notifier.service
+
+import com.monta.slack.notifier.SlackClient.MessageResponse
+import com.monta.slack.notifier.SlackClient.Response
+import com.monta.slack.notifier.SlackHttpClient
+import com.monta.slack.notifier.model.GithubEvent
+import com.monta.slack.notifier.model.JobStatus
+import com.monta.slack.notifier.model.JobType
+import com.monta.slack.notifier.model.SlackMessage
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class TestSlackHttpClient(input: Input) : SlackHttpClient(input) {
+
+    val sentMessages = mutableListOf<SlackMessage>()
+
+    override suspend fun getSlackMessageById(
+        messageId: String,
+    ): MessageResponse? {
+        return MessageResponse(true, sentMessages.toList())
+    }
+
+    override suspend fun makeSlackRequest(url: String, message: SlackMessage): Response? {
+        sentMessages.add(message)
+        return Response(true, "channel", "00:00:00")
+    }
+
+    fun listMessages(): List<SlackMessage> {
+        return sentMessages.toList()
+    }
+}
+
+class PublishSlackServiceTest {
+    @Test
+    fun test_replacing_attachments() {
+        val input = Input(
+            serviceName = "gineau pig",
+            serviceEmoji = "🐷",
+            slackToken = "token",
+            slackChannelId = "#anni-test",
+            appendAttachments = false
+        )
+        val testSlackHttpClient = TestSlackHttpClient(input)
+        val service = PublishSlackService(
+            input = input,
+            testSlackHttpClient
+        )
+        runTest {
+            // given one message is published
+            service.publish(
+                githubEvent = GithubEvent(
+                    "repository",
+                    "master",
+                    "1",
+                    "nickelsen",
+                    "a1b2c3d4",
+                    "message",
+                    "workflow",
+                    "url"
+                ),
+                jobType = JobType.Test,
+                jobStatus = JobStatus.Progress,
+                slackMessageId = null
+            )
+            val slackMessagesBefore = testSlackHttpClient.listMessages()
+            slackMessagesBefore.size shouldBe 1
+            slackMessagesBefore.first().attachments?.size shouldBe 1
+
+            // when a second message is published
+            service.publish(
+                githubEvent = GithubEvent(
+                    "repository",
+                    "master",
+                    "1",
+                    "nickelsen",
+                    "a1b2c3d4",
+                    "message",
+                    "workflow",
+                    "url"
+                ),
+                jobType = JobType.Test,
+                jobStatus = JobStatus.Success,
+                slackMessageId = "00:00:00"
+            )
+
+            // then the attachment of the second message is replaced
+            val slackMessagesAfter = testSlackHttpClient.listMessages()
+            slackMessagesAfter.size shouldBe 2
+            slackMessagesAfter.last().attachments?.size shouldBe 1
+
+        }
+
+    }
+
+    @Test
+    fun test_appending_attachments() {
+        val input = Input(
+            serviceName = "gineau pig",
+            serviceEmoji = "🐷",
+            slackToken = "token",
+            slackChannelId = "#anni-test",
+            appendAttachments = true
+        )
+        val testSlackHttpClient = TestSlackHttpClient(input)
+        val service = PublishSlackService(
+            input = input,
+            testSlackHttpClient
+        )
+        runTest {
+            // given one message is published
+            service.publish(
+                githubEvent = GithubEvent(
+                    "repository",
+                    "master",
+                    "1",
+                    "nickelsen",
+                    "a1b2c3d4",
+                    "message",
+                    "workflow",
+                    "url"
+                ),
+                jobType = JobType.Test,
+                jobStatus = JobStatus.Progress,
+                slackMessageId = null
+            )
+            val slackMessagesBefore = testSlackHttpClient.listMessages()
+            slackMessagesBefore.size shouldBe 1
+            slackMessagesBefore.first().attachments?.size shouldBe 1
+
+            // when a second message is published
+            service.publish(
+                githubEvent = GithubEvent(
+                    "repository",
+                    "master",
+                    "1",
+                    "nickelsen",
+                    "a1b2c3d4",
+                    "message",
+                    "workflow",
+                    "url"
+                ),
+                jobType = JobType.Test,
+                jobStatus = JobStatus.Success,
+                slackMessageId = "00:00:00"
+            )
+
+            // then an additional attachment is added to the second message
+            val slackMessagesAfter = testSlackHttpClient.listMessages()
+            slackMessagesAfter.size shouldBe 2
+            slackMessagesAfter.last().attachments?.size shouldBe 2
+        }
+    }
+}

--- a/src/commonTest/kotlin/com/monta/slack/notifier/service/PublishSlackServiceTest.kt
+++ b/src/commonTest/kotlin/com/monta/slack/notifier/service/PublishSlackServiceTest.kt
@@ -11,7 +11,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
-class TestSlackHttpClient(input: Input) : SlackHttpClient(input) {
+class TestSlackHttpClient(slackToken: String, slackChannelId: String) : SlackHttpClient(slackToken, slackChannelId) {
 
     val sentMessages = mutableListOf<SlackMessage>()
 
@@ -34,16 +34,12 @@ class TestSlackHttpClient(input: Input) : SlackHttpClient(input) {
 class PublishSlackServiceTest {
     @Test
     fun test_replacing_attachments() {
-        val input = Input(
+        val testSlackHttpClient = TestSlackHttpClient("token", "#monta")
+        val service = PublishSlackService(
             serviceName = "gineau pig",
             serviceEmoji = "🐷",
-            slackToken = "token",
-            slackChannelId = "#anni-test",
-            appendAttachments = false
-        )
-        val testSlackHttpClient = TestSlackHttpClient(input)
-        val service = PublishSlackService(
-            input = input,
+            slackChannelId = "#monta",
+            appendAttachments = false,
             testSlackHttpClient
         )
         runTest {
@@ -53,7 +49,7 @@ class PublishSlackServiceTest {
                     "repository",
                     "master",
                     "1",
-                    "nickelsen",
+                    "monta",
                     "a1b2c3d4",
                     "message",
                     "workflow",
@@ -73,7 +69,7 @@ class PublishSlackServiceTest {
                     "repository",
                     "master",
                     "1",
-                    "nickelsen",
+                    "monta",
                     "a1b2c3d4",
                     "message",
                     "workflow",
@@ -95,16 +91,12 @@ class PublishSlackServiceTest {
 
     @Test
     fun test_appending_attachments() {
-        val input = Input(
+        val testSlackHttpClient = TestSlackHttpClient("token", "#monta")
+        val service = PublishSlackService(
             serviceName = "gineau pig",
             serviceEmoji = "🐷",
-            slackToken = "token",
-            slackChannelId = "#anni-test",
-            appendAttachments = true
-        )
-        val testSlackHttpClient = TestSlackHttpClient(input)
-        val service = PublishSlackService(
-            input = input,
+            slackChannelId = "#monta",
+            appendAttachments = true,
             testSlackHttpClient
         )
         runTest {
@@ -114,7 +106,7 @@ class PublishSlackServiceTest {
                     "repository",
                     "master",
                     "1",
-                    "nickelsen",
+                    "monta",
                     "a1b2c3d4",
                     "message",
                     "workflow",
@@ -134,7 +126,7 @@ class PublishSlackServiceTest {
                     "repository",
                     "master",
                     "1",
-                    "nickelsen",
+                    "monta",
                     "a1b2c3d4",
                     "message",
                     "workflow",


### PR DESCRIPTION
For php release flow, we would like timestamps on the events, e.g. when build started, when deploy finished. To support that, I've added a flag called `append-status-updates` which will add new attachments with status updates incl timestamp to existing slack messages instead of replacing them with new status.

I've added two tests; one of the replacing functionality and one of the appending functionality
To make the tests work, I had to inject a layer between the message builder and the http client in `SlackClient`, which I call `SlackHttpClient`, which I then replace with a fake instance during testing, to assert on the messages and content that would be sent to slack.

Disclaimer: This is my first Kotlin PR ever, so I accept a lot of feedback. :D 