### PR TITLE
feat: Add skipped status

### DIFF
--- a/src/commonMain/kotlin/com/monta/slack/notifier/model/JobStatus.kt
+++ b/src/commonMain/kotlin/com/monta/slack/notifier/model/JobStatus.kt
@@ -20,6 +20,10 @@ enum class JobStatus(
         message = "Cancelled :warning:",
         color = "#FFFF00"
     ),
+    Skipped(
+        message = "Skipped :wave:",
+        color = "#C4C4C4"
+    ),
     Unknown(
         message = "Something went wrong :question:",
         color = "#DBAB09"


### PR DESCRIPTION
In the shared github workflows, we sometimes [notify based on `job.result`](https://github.com/monta-app/github-workflows/blob/v2/.github/workflows/deploy.yaml#L587), which can be `skipped`.

With the new continuous deployment model, we skip tests during deploy, so it would be nice to be able to notify about that, even if [`skipped` is not technically a `job.status` value](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#job-context).