### PR TITLE
chore: Change runners for all binary builds to x64 [NOJIRA]

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   create-tag-and-build:
-    runs-on: linux-arm64
+    runs-on: linux-x64
     outputs:
       new_version: ${{ steps.create_tag.outputs.new_version }}
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,7 +4,7 @@ on: [ pull_request ]
 
 jobs:
   build:
-    runs-on: linux-arm64
+    runs-on: linux-x64
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: linux-arm64
+    runs-on: linux-x64
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK


### PR DESCRIPTION
The arm runners can not emulate x86, so not possible to build binaries on those