### PR TITLE
fix: Configure renovate to pin external github actions to avoid supply chain attacks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,23 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    "helpers:pinGitHubActionDigests",
     ":semanticCommitTypeAll(chore)"
   ],
-  "packageRules": [
-    {
-      "groupName": "upgrade all gradle dependencies",
-      "matchManagers": [
-        "gradle"
-      ],
-      "groupSlug": "gradle",
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "major"
-      ],
-      "matchPackageNames": [
-        "*"
-      ]
-    }
-  ]
+  "semanticCommits": "enabled",
+  "prConcurrentLimit": 2,
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
do not group gradle dependencies (aligned with how it is set up in changelog-cli)